### PR TITLE
Disable leaflet's default animation for transitioning from one coord to another

### DIFF
--- a/src/views/pages/posts/MapPositionSelect.js
+++ b/src/views/pages/posts/MapPositionSelect.js
@@ -157,7 +157,9 @@ export default function MapPositionSelect(props) {
       }
 
       userMarkerRef.current.setLatLng(newLatLng);
-      mapRef.current?.flyTo(newLatLng);
+      mapRef.current?.flyTo(newLatLng, undefined, {
+          animate: false
+        });
     }
   }, [props?.latitude, props?.longitude, location]);
 


### PR DESCRIPTION
Reference issue: https://github.com/uvercorp/uverwatch-v2-build/issues/3